### PR TITLE
refactor(gui): modular default dataset loader

### DIFF
--- a/atlas_dearpygui_gui/atlas_nodes/data_sources/default_dataset_node.py
+++ b/atlas_dearpygui_gui/atlas_nodes/data_sources/default_dataset_node.py
@@ -1,42 +1,61 @@
-"""
-Default Dataset Node
-Provides a pre-loaded sample dataset for immediate testing and demonstration
-"""
+"""Default Dataset Node
+Provides a pre-loaded sample dataset for immediate testing and demonstration."""
 
-import json
-import os
 import dearpygui.dearpygui as dpg
 from typing import Dict, List, Optional, Any
-import sys
-from pathlib import Path
 
-# Add parent directory to path for imports
-parent_dir = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(parent_dir))
-from atlas_node_abc import AtlasNodeABC
+from atlas_dearpygui_gui.atlas_node_abc import AtlasNodeABC
+from atlas_dearpygui_gui.utils.default_dataset_loader import (
+    load_default_dataset,
+    format_dataset,
+)
 
 
 class Node(AtlasNodeABC):
     """Default dataset node with pre-loaded sample data."""
 
+    node_label = "Default Dataset"
+    node_tag = "DefaultDataset"
+
     def __init__(self):
         super().__init__()
-        self.node_tag = "default_dataset"
         self._dataset_loaded = False
-        self._sample_data = None
+        self._sample_data: Optional[Dict[str, Any]] = None
+        self._status_text = None
 
-    def add_node(self, parent: int, node_id: int, pos: list, size: list = [200, 150]) -> int:
+    def add_node(
+        self,
+        parent: str,
+        node_id: int,
+        pos: List[int],
+        atlas_config: Optional[Dict] = None,
+        callback: Optional[callable] = None,
+        size: List[int] = [200, 150],
+    ) -> str:
         """Create the default dataset node."""
+
+        tag_node_name = f"{node_id}:{self.node_tag}"
+        tag_output01 = f"{tag_node_name}:{self.TYPE_TIME_SERIES}:Output01"
+        tag_output01_value = f"{tag_node_name}:{self.TYPE_TIME_SERIES}:Output01Value"
+
+        # Check auto load option
+        self._auto_load = False
+        if atlas_config:
+            default_cfg = atlas_config.get("default_dataset", {})
+            self._auto_load = default_cfg.get("auto_load", False)
+
         with dpg.node(
             parent=parent,
-            tag=node_id,
-            label="Default Dataset",
+            tag=tag_node_name,
+            label=self.node_label,
             pos=pos,
-            size=size
         ):
             # Output port for time series data
-            with dpg.node_attribute(attribute_type=dpg.mvNode_Attr_Output, tag=str(node_id) + ':' + self.TYPE_TIME_SERIES + ':Output01Value'):
-                dpg.add_text("Time Series Data")
+            with dpg.node_attribute(
+                attribute_type=dpg.mvNode_Attr_Output,
+                tag=tag_output01,
+            ):
+                dpg.add_text(tag=tag_output01_value, default_value="Time Series Data")
 
             # Load dataset button
             with dpg.node_attribute(attribute_type=dpg.mvNode_Attr_Static):
@@ -44,93 +63,62 @@ class Node(AtlasNodeABC):
                     label="Load Sample Data",
                     callback=self._load_sample_data,
                     user_data=node_id,
-                    width=size[0] - 20
+                    width=size[0] - 20,
                 )
 
             # Status display
             with dpg.node_attribute(attribute_type=dpg.mvNode_Attr_Static):
-                self._status_text = dpg.add_text("Click to load sample data", wrap=size[0] - 20)
+                self._status_text = dpg.add_text(
+                    "Click to load sample data", wrap=size[0] - 20
+                )
 
-        return node_id
+        if self._auto_load:
+            self._load_sample_data(None, None, node_id)
+
+        return tag_node_name
 
     def _load_sample_data(self, sender, app_data, user_data):
-        """Load the sample dataset."""
-        node_id = user_data
-
+        """Load the sample dataset using the shared loader."""
         try:
-            # Load default dataset
-            data_file = Path(__file__).parent.parent.parent / 'data' / 'default_dataset.json'
-            if data_file.exists():
-                with data_file.open('r') as f:
-                    self._sample_data = json.load(f)
-
-                self._dataset_loaded = True
-
-                # Update status
-                dpg.set_value(self._status_text, f"Loaded: {len(self._sample_data.get('plots', []))} plots")
-
-                print(f"Default dataset loaded successfully from {data_file}")
-            else:
-                dpg.set_value(self._status_text, "Error: Default dataset not found")
-                print(f"Default dataset file not found: {data_file}")
-
+            self._sample_data = load_default_dataset()
+            self._dataset_loaded = True
+            dpg.set_value(
+                self._status_text,
+                f"Loaded: {len(self._sample_data.get('plots', []))} plots",
+            )
         except Exception as e:
-            dpg.set_value(self._status_text, f"Error loading dataset: {str(e)}")
-            print(f"Error loading default dataset: {e}")
+            dpg.set_value(self._status_text, f"Error loading dataset: {e}")
 
-    def update(self, node_id: int, node_data_dict: Dict, node_result_dict: Dict) -> None:
+    def update(
+        self,
+        node_id: int,
+        connection_list: List[List[str]],
+        node_data_dict: Dict[str, Any],
+        node_result_dict: Dict[str, Any],
+    ) -> tuple:
         """Update the node with sample data."""
         if not self._dataset_loaded or not self._sample_data:
-            return
+            return None, {"status": "no_data"}
 
-        # Create time series data from the sample dataset
-        time_series_data = []
-
-        for plot in self._sample_data.get('plots', []):
-            for line in plot.get('lines', []):
-                line_data = line.get('data', {})
-                if 'data' in line_data:
-                    ts_data = line_data['data']
-                    time_series_data.append({
-                        'tags': line_data.get('tags', {}),
-                        'label': line_data.get('label', 'Unknown'),
-                        'start_time': ts_data.get('startTime'),
-                        'step': ts_data.get('step', 60000),
-                        'values': ts_data.get('values', []),
-                        'color': line.get('color', '#1f77b4'),
-                        'line_width': line.get('lineWidth', 2)
-                    })
-
-        # Store the processed data
-        node_data_dict[node_id] = {
-            'time_series': time_series_data,
-            'metadata': {
-                'title': self._sample_data.get('title', 'Default Dataset'),
-                'start_time': self._sample_data.get('startTime'),
-                'end_time': self._sample_data.get('endTime'),
-                'step': self._sample_data.get('step', 60000),
-                'source': 'default_dataset'
-            }
+        data = format_dataset(self._sample_data)
+        time_series = data.get("time_series", [])
+        result = {
+            "status": "success",
+            "message": f"Loaded {len(time_series)} time series",
+            "data_points": sum(len(ts["data"]["values"]) for ts in time_series),
         }
-
-        node_result_dict[node_id] = {
-            'status': 'success',
-            'message': f'Loaded {len(time_series_data)} time series',
-            'data_points': sum(len(ts['values']) for ts in time_series_data)
-        }
+        return data, result
 
     def get_setting_dict(self, node_id: int) -> Dict:
         """Get node settings for saving."""
         return {
-            'dataset_loaded': self._dataset_loaded,
-            'node_type': 'default_dataset'
+            "dataset_loaded": self._dataset_loaded,
+            "node_type": "default_dataset",
         }
 
     def set_setting_dict(self, node_id: int, setting: Dict) -> None:
         """Restore node settings from saved data."""
-        self._dataset_loaded = setting.get('dataset_loaded', False)
-
-        # If dataset was loaded, reload it
+        self._dataset_loaded = setting.get("dataset_loaded", False)
         if self._dataset_loaded:
             self._load_sample_data(None, None, node_id)
 

--- a/atlas_dearpygui_gui/tests/test_default_dataset_loader.py
+++ b/atlas_dearpygui_gui/tests/test_default_dataset_loader.py
@@ -1,0 +1,25 @@
+import unittest
+
+from atlas_dearpygui_gui.utils.default_dataset_loader import (
+    load_default_dataset,
+    format_dataset,
+)
+
+
+class TestDefaultDatasetLoader(unittest.TestCase):
+    def test_load_and_format(self):
+        raw = load_default_dataset()
+        self.assertIn("plots", raw)
+
+        formatted = format_dataset(raw)
+        self.assertIn("time_series", formatted)
+        self.assertGreater(len(formatted["time_series"]), 0)
+
+        first = formatted["time_series"][0]
+        self.assertIsInstance(first["data"]["startTime"], (int, float))
+        self.assertIn("metadata", formatted)
+        self.assertEqual(formatted["metadata"]["source"], "default_dataset")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atlas_dearpygui_gui/tests/test_default_view.py
+++ b/atlas_dearpygui_gui/tests/test_default_view.py
@@ -1,0 +1,66 @@
+import unittest
+from collections import OrderedDict
+from pathlib import Path
+
+import dearpygui.dearpygui as dpg
+
+from atlas_dearpygui_gui.main import (
+    load_atlas_config,
+    initialize_default_view,
+    update_node_info,
+)
+from atlas_dearpygui_gui.atlas_node_editor import AtlasNodeEditor
+
+
+class TestDefaultView(unittest.TestCase):
+    def setUp(self):
+        dpg.create_context()
+        dpg.create_viewport(width=600, height=400)
+        dpg.setup_dearpygui()
+
+    def tearDown(self):
+        if dpg.is_viewport_created():
+            dpg.destroy_viewport()
+        # destroy_context triggers a segfault with Dear PyGui 2.x in headless mode
+        # so we rely on interpreter cleanup after tests
+
+    def _create_editor(self, config):
+        base_dir = Path(__file__).resolve().parents[1]
+        menu = OrderedDict({
+            "Data Sources": "data_sources",
+            "Visualization": "visualization",
+        })
+        return AtlasNodeEditor(
+            width=600,
+            height=400,
+            atlas_config=config,
+            menu_dict=menu,
+            node_dir=str(base_dir / "atlas_nodes"),
+        )
+
+    def test_default_dataset_autoloads_and_renders(self):
+        base_dir = Path(__file__).resolve().parents[1]
+        config_path = base_dir / "config" / "atlas_config.json"
+        config = load_atlas_config(str(config_path))
+        config.setdefault("default_dataset", {})
+        config["default_dataset"].update({"enabled": True, "auto_load": True})
+
+        editor = self._create_editor(config)
+        initialize_default_view(editor, config)
+
+        dataset_instance = editor.get_node_instance("DefaultDataset")
+        self.assertTrue(dataset_instance._dataset_loaded)
+        self.assertIsNotNone(dataset_instance._sample_data)
+
+        node_data = {}
+        node_results = {}
+        update_node_info(editor, node_data, node_results, mode_async=False)
+
+        chart_tag = next(n for n in editor.get_node_list() if n.endswith(":LineChart"))
+        chart_data = node_data.get(chart_tag)
+        self.assertIsNotNone(chart_data)
+        self.assertGreater(len(chart_data.get("series", [])), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/atlas_dearpygui_gui/utils/default_dataset_loader.py
+++ b/atlas_dearpygui_gui/utils/default_dataset_loader.py
@@ -1,0 +1,67 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Default path to the bundled sample dataset
+DEFAULT_DATASET_PATH = (
+    Path(__file__).resolve().parents[1] / "data" / "default_dataset.json"
+)
+
+def load_default_dataset(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load the bundled default dataset from disk.
+
+    Parameters
+    ----------
+    path:
+        Optional path override. If None, the built-in dataset is used.
+    """
+    data_path = path or DEFAULT_DATASET_PATH
+    with data_path.open("r") as f:
+        return json.load(f)
+
+def _parse_time(ts: Optional[str]) -> Optional[int]:
+    """Convert an ISO timestamp to epoch milliseconds."""
+    if isinstance(ts, str):
+        try:
+            return int(
+                datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp() * 1000
+            )
+        except Exception:
+            return None
+    return ts
+
+def format_dataset(sample_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Transform raw sample data into chart-friendly structure."""
+    time_series: List[Dict[str, Any]] = []
+    for plot in sample_data.get("plots", []):
+        for line in plot.get("lines", []):
+            line_data = line.get("data", {})
+            ts = line_data.get("data", {})
+            start = ts.get("startTime")
+            if isinstance(start, str):
+                start = datetime.fromisoformat(start.replace("Z", "+00:00")).timestamp() * 1000
+            time_series.append(
+                {
+                    "tags": line_data.get("tags", {}),
+                    "label": line_data.get("label", "Unknown"),
+                    "data": {
+                        "startTime": start,
+                        "step": ts.get("step", 60000),
+                        "values": ts.get("values", []),
+                    },
+                    "color": line.get("color", "#1f77b4"),
+                    "line_width": line.get("lineWidth", 2),
+                }
+            )
+
+    return {
+        "time_series": time_series,
+        "metadata": {
+            "title": sample_data.get("title", "Default Dataset"),
+            "start_time": _parse_time(sample_data.get("startTime")),
+            "end_time": _parse_time(sample_data.get("endTime")),
+            "step": sample_data.get("step", 60000),
+            "source": "default_dataset",
+        },
+    }


### PR DESCRIPTION
## Summary
- separate sample dataset loading into a reusable utility
- simplify default dataset node to use the shared loader
- add unit test for dataset loader alongside existing GUI test

## Testing
- `python -m py_compile atlas_dearpygui_gui/utils/default_dataset_loader.py atlas_dearpygui_gui/atlas_nodes/data_sources/default_dataset_node.py atlas_dearpygui_gui/tests/test_default_dataset_loader.py atlas_dearpygui_gui/tests/test_default_view.py atlas_dearpygui_gui/main.py`
- `python -m pre_commit run --files atlas_dearpygui_gui/atlas_nodes/data_sources/default_dataset_node.py atlas_dearpygui_gui/utils/default_dataset_loader.py atlas_dearpygui_gui/tests/test_default_dataset_loader.py atlas_dearpygui_gui/tests/test_default_view.py atlas_dearpygui_gui/main.py`
- `python -m pytest atlas_dearpygui_gui/tests/test_default_dataset_loader.py atlas_dearpygui_gui/tests/test_default_view.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1224b0cac8322b7b4550df8e55556